### PR TITLE
Fix ex5.ml

### DIFF
--- a/intro_return_t/ex5.ml
+++ b/intro_return_t/ex5.ml
@@ -23,10 +23,9 @@ let parse_age age =
     ~error:(`Bad_age age)
 
 let parse_zip zip =
-  if String.length zip = 5 && int_of_string zip <> None then
-    Ok zip
-  else
-    Error (`Bad_zip zip)
+  match int_of_string zip with
+  | Some _ when String.length zip = 5 -> Ok zip
+  | _ -> Error (`Bad_zip zip)
 
 let parse_person s =
   match String.split ~on:'\t' s with


### PR DESCRIPTION
The original version does not compile, as the expression (int_of_string zip) line 26 triggers the following:
Error: This expression has type int option
       but an expression was expected of type int